### PR TITLE
dock_calibrate improvements

### DIFF
--- a/Klipper/config/dock_calibrate.cfg
+++ b/Klipper/config/dock_calibrate.cfg
@@ -1,8 +1,23 @@
+# dock_calbrate helps automaticaly find the location of the dock, saving the user from manaaly jogging the carriage into possition.
+#
+# Requirements:
+# - make sure your printer can home all axis
+# - Edit the the gcode sections below: `dock_calibrate_move_1_gcode` and `dock_calibrate_move_2_gcode`,
+#   they are executed in sequence. move_1_gcode should undock the toolhead and move_2_gcode should safely home from undocked location.
+# - try the commands in this gcodes manually first to ensure the carriage will NOT crash into anything.
+# - IMPORTANT: Double check the move_1_gcode and the direction of the X movement!
+#
+# Usage:
+# - Turn off the printer motors so the carriage can be moved freely by hand.
+# - Attach the target toolhead to it's dock
+# - Physicaly move the carriage to the toolhead and make sure it sits against it (in docked position) nice and snug.
+# - Run the Gcode macro substituting the tool name, for example: CALC_DOCK_LOCATION TOOL=0
+#
 [dock_calibrate]
 dock_calibrate_move_1_gcode:
 	SET_KINEMATIC_POSITION X=50 Y=350
 	G91
-	G1 X-14 F3000
+	G1 X-14 F3000  # Important: double check this is correct direction. It would generaly be negative for rear mounted toolheads, positive for front mounted docks. Check the distance is correct for your toolchanger.
 	G1 X2 F3000
 dock_calibrate_move_2_gcode:
 	G28 Y
@@ -24,11 +39,11 @@ dock_test_gcode:
 		KTCC_TOOL_DROPOFF_ALL
 		T{printer["gcode_macro VARIABLES_LIST"].active_tool}
 	{% endfor %}
-xy_resolution: 0.003125
-dock_extra_offset_x_unlock:0.5
-dock_extra_offset_y_unlock:0.2
-dock_extra_offset_x_lock:0.5
-dock_extra_offset_y_lock:0.8
+xy_resolution: 0.003125 # not used
+dock_extra_offset_x_unlock:0.0
+dock_extra_offset_y_unlock:0.0
+dock_extra_offset_x_lock:0.0
+dock_extra_offset_y_lock:0.0
 
 
 [gcode_macro DOCK_TEST_MANUAL]

--- a/Klipper/modules/Dock_Calibrate/dock_calibrate.py
+++ b/Klipper/modules/Dock_Calibrate/dock_calibrate.py
@@ -1,16 +1,16 @@
-# Nozzle alignment module for 3d kinematic probes.
-#
-# This module has been adapted from code written by Kevin O'Connor <kevin@koconnor.net> and Martin Hierholzer <martin@hierholzer.info>
-# Sourced from https://github.com/ben5459/Klipper_ToolChanger/blob/master/probe_multi_axis.py
+# Automatic Dock position location for DakshV2
 
-import logging
+from kinematics import cartesian, corexy
 
 
 class DockCalibrate:
 	def __init__(self, config):
+		self.config = config
 		self.printer = config.get_printer()
 		self.name = config.get_name()
-		self.xy_resolution = config.getfloat('xy_resolution')
+		self.xy_resolution = config.getfloat('xy_resolution') # no longer needed, leaving this in so the script doesn't error for existing users
+		self.x_resolution = None
+		self.y_resolution = None
 		self.dock_extra_offset_x_unlock = config.getfloat('dock_extra_offset_x_unlock')
 		self.dock_extra_offset_y_unlock = config.getfloat('dock_extra_offset_y_unlock')
 		self.dock_extra_offset_x_lock = config.getfloat('dock_extra_offset_x_lock')
@@ -18,64 +18,133 @@ class DockCalibrate:
 		self.gcode = self.printer.lookup_object('gcode')
 		gcode_macro = self.printer.load_object(config, 'gcode_macro')
 		# G-Code macros
-		self.dock_calibrate_move_1_template = gcode_macro.load_template(config, 'dock_calibrate_move_1_gcode', '')
-		self.dock_calibrate_move_2_template = gcode_macro.load_template(config, 'dock_calibrate_move_2_gcode', '')
+		self.dock_calibrate_unlock_template = gcode_macro.load_template(config, 'dock_calibrate_move_1_gcode', '')
+		self.dock_calibrate_home_template = gcode_macro.load_template(config, 'dock_calibrate_move_2_gcode', '')
 		self.dock_test_template = gcode_macro.load_template(config, 'dock_test_gcode', '')
 		self.rod_install_msg_template = gcode_macro.load_template(config, 'rod_install_msg_gcode', '')
-		
-		
+
+
 		self.gcode.register_command('CALC_DOCK_LOCATION', self.cmd_CALC_DOCK_LOCATION,
 		desc=self.cmd_CALC_DOCK_LOCATION_help)
 
 		self.gcode.register_command('DOCK_TEST', self.cmd_DOCK_TEST,
 		desc=self.cmd_DOCK_TEST_help)
-		
-	def get_status(self, eventtime):		
+
+	def get_status(self, eventtime):
 		return {}
-				
-	def get_mcu_position(self):		
+
+	def get_printer_type(self):
+		try:
+			toolhead = self.printer.lookup_object('toolhead')
+			kin = toolhead.get_kinematics()
+			steppers = kin.get_steppers()
+			self.console(f"stepx: {steppers[0].get_step_dist()}, stepy:{steppers[1].get_step_dist()}")
+			self.x_resolution = steppers[0].get_step_dist()
+			self.y_resolution = steppers[1].get_step_dist()
+			kinematics_type = str(type(kin))
+			if isinstance(kin, cartesian.CartKinematics):
+				self.console("this is a cartesian printer")
+				return "cartesian"
+			elif isinstance(kin, corexy.CoreXYKinematics):
+				self.console("this is a corexy printer")
+				return "corexy"
+			else:
+				self.console(f"Unsupported kinematics type: {kinematics_type}. Cannot continue")
+
+		except Exception as e:
+			self.console(f"Error: {e}")
+		return None
+
+	def get_mcu_position(self):
 		toolhead = self.printer.lookup_object('toolhead')
 		steppers = toolhead.kin.get_steppers()
 		for s in steppers:
 			if s.get_name() == "stepper_x":
 				mcu_pos_x = s.get_mcu_position()
-	  	
+
 			if s.get_name() == "stepper_y":
 				mcu_pos_y = s.get_mcu_position()
-			
+
 		return {'x':mcu_pos_x,
 				'y':mcu_pos_y}
 
+	def get_toolhead_position(self):
+		toolhead = self.printer.lookup_object('toolhead')
+		pos = toolhead.get_position()
+		return pos
+
+	def console(self, msg):
+		self.gcode.run_script_from_command(f"RESPOND TYPE=command MSG='{msg}'")
+		self.gcode.run_script_from_command(f"M117 {msg}")
+
 	cmd_CALC_DOCK_LOCATION_help = "Automatically Calculate Dock Location for Selected Tool"
 	def cmd_CALC_DOCK_LOCATION(self, gcmd):
+		printer_type = self.get_printer_type()
+		if not printer_type:
+			gcmd.respond_info("ERROR: this printer kinematics type is not supported. Canceling calibration")
+			return
 		tool = gcmd.get("TOOL")
 		toolhead = self.printer.lookup_object('toolhead')
 
+		#get starting position, this is tool docked
+		self.console("Starting dock calibration")
 		initial_res = self.get_mcu_position();
-		logging.info(initial_res)
-		self.dock_calibrate_move_1_template.run_gcode_from_command()
-		self.gcode.run_script_from_command('G4 P2000')
-		move_1_res = self.get_mcu_position();
-		logging.info(move_1_res)
-		self.dock_calibrate_move_2_template.run_gcode_from_command()
-		self.gcode.run_script_from_command('G4 P2000')
-		move_2_res = self.get_mcu_position();
-		logging.info(move_2_res)
-		
-		dx2 = move_2_res['x'] - move_1_res['x']
-		dy2 = move_2_res['y'] - move_1_res['y']
 
-		unlock_x = -(((dx2 + dy2)/2) * self.xy_resolution) + self.dock_extra_offset_x_unlock
-		unlock_y = -(((dx2 - dy2)/2) * self.xy_resolution) + self.dock_extra_offset_y_unlock
+		#run first move to unlock the tool
+		self.console("Running first Gcode move: Moving to unlock the tool")
+		self.dock_calibrate_unlock_template.run_gcode_from_command()
+		self.gcode.run_script_from_command('G4 P2000')
+		unlock_res = self.get_mcu_position();
 
-		dx1 = move_2_res['x'] - initial_res['x']
-		dy1 = move_2_res['y'] - initial_res['y']
-		
-		
-		lock_x = -(((dx1 + dy1)/2) * self.xy_resolution) + self.dock_extra_offset_x_lock
-		lock_y = -(((dx1 - dy1)/2) * self.xy_resolution) + self.dock_extra_offset_y_lock
-		
-	
+		#run second move to home the axes
+		self.console("Running second Gcode move: Homing axes")
+		self.dock_calibrate_home_template.run_gcode_from_command()
+		self.gcode.run_script_from_command('G4 P2000')
+		home_res = self.get_mcu_position();
+
+		real_pos = self.get_toolhead_position() # returns position array [X,Y,Z,E]
+		self.console(f"real_pos: {real_pos[0]}, {real_pos[1]}, {real_pos[2]}")
+		if printer_type == "cartesian":
+			dx2 = home_res['x'] - unlock_res['x']
+			dy2 = home_res['y'] - unlock_res['y']
+
+			unlock_x = real_pos[0]-(dx2 * self.x_resolution) + self.dock_extra_offset_x_unlock
+			unlock_y = real_pos[1]-(dy2 * self.y_resolution) + self.dock_extra_offset_y_unlock
+
+			dx1 = home_res['x'] - initial_res['x']
+			dy1 = home_res['y'] - initial_res['y']
+
+			lock_x = real_pos[0]-(dx1 * self.x_resolution) + self.dock_extra_offset_x_lock
+			lock_y = real_pos[1]-(dy1 * self.y_resolution) + self.dock_extra_offset_y_lock
+
+		elif printer_type == "corexy":
+			# get unlock coordinates
+			dx2 = home_res['x'] - unlock_res['x']
+			dy2 = home_res['y'] - unlock_res['y']
+			unlock_move_diff_x = (dx2*self.x_resolution + dy2*self.y_resolution)/2 
+			unlock_move_diff_y = (dx2*self.x_resolution - dy2*self.y_resolution)/2 
+			unlock_x = real_pos[0]-unlock_move_diff_x + self.dock_extra_offset_x_unlock
+			unlock_y = real_pos[1]-unlock_move_diff_y + self.dock_extra_offset_y_unlock
+
+			# get docked coordinates
+			dx1 = home_res['x'] - initial_res['x']
+			dy1 = home_res['y'] - initial_res['y']
+
+			move_diff_x = (dx1*self.x_resolution + dy1*self.y_resolution)/2 
+			move_diff_y = (dx1*self.x_resolution - dy1*self.y_resolution)/2 
+
+			lock_x = real_pos[0]-move_diff_x + self.dock_extra_offset_x_lock
+			lock_y = real_pos[1]-move_diff_y + self.dock_extra_offset_y_lock
+		else:
+			return
+
+		lock_x = round(lock_x, 2)
+		lock_y = round(lock_y, 2)
+		unlock_x = round(unlock_x, 2)
+		unlock_y = round(unlock_y, 2)
+
+		gcmd.respond_info(f"Calculated dock location: X{lock_x}, Y{lock_y}")	
+
 		save_variables = self.printer.lookup_object('save_variables')
 
 		save_variables.cmd_SAVE_VARIABLE(self.gcode.create_gcode_command("SAVE_VARIABLE", "SAVE_VARIABLE", {"VARIABLE": 't'+tool+'_lock_x', 'VALUE': round(lock_x, 2) }))
@@ -83,12 +152,12 @@ class DockCalibrate:
 
 		save_variables.cmd_SAVE_VARIABLE(self.gcode.create_gcode_command("SAVE_VARIABLE", "SAVE_VARIABLE", {"VARIABLE": 't'+tool+'_unlock_x', 'VALUE': round(unlock_x, 2) }))
 		save_variables.cmd_SAVE_VARIABLE(self.gcode.create_gcode_command("SAVE_VARIABLE", "SAVE_VARIABLE", {"VARIABLE": 't'+tool+'_unlock_y', 'VALUE': round(unlock_y, 2) }))
-	
-			
+
+
 	cmd_DOCK_TEST_help = "Automatically Calculate Dock Location for Selected Tool"
 	def cmd_DOCK_TEST(self, gcmd):
 		self.rod_install_msg_template.run_gcode_from_command()
 		self.dock_test_template.run_gcode_from_command()
-						
+
 def load_config(config):
 	return DockCalibrate(config)


### PR DESCRIPTION
Some tweaks and improvements to the awesome dock_calibrate.py script:

- add support for cartesian kinematics in addition to corexy (will quit if unknown kinematics is defined)
- add support for kalico klippepr for for kinematic identificatin
- add console output for calculated dock location
- use endstop values from printer configuration, so the endstops can be anywhere, not only at 0,0.
- use step distance from config file, xy_resolution no longer neeed to be defined manually

Usage remains unchanged and will work with existing `[dock_calibrate.cfg]` files.
There is no longer need to move the toolhead to 0,0 if printer endstops are placed somewhere else.